### PR TITLE
Remove dependence on serde derive feature for production

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.85"
 
 [dependencies]
 fast-float2 = "0.2.3"
-serde = { version = "1.0.219", features = ["derive"], optional = true }
+serde = { version = "1.0.219", optional = true }
 
 [features]
 default = ["serde"]
@@ -22,3 +22,4 @@ serde = ["dep:serde"]
 
 [dev-dependencies]
 rstest = "0.26.1"
+serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
Now there is no need to depend on the syn ecosystem to build. Drops clean builds from 7.5s to 1.25s